### PR TITLE
Dockerize frontend; use orjson encoder/decoder

### DIFF
--- a/assets/dashAgGridComponentFunctions.js
+++ b/assets/dashAgGridComponentFunctions.js
@@ -18,7 +18,7 @@ dagcomponentfuncs.des_result_link = function (props) {
     }
     return React.createElement(
         'a',
-        { href: '/des/result/' + props.value },
+        { href: 'des/result/' + props.value },
         'Result'
     );
 };

--- a/compose.override.yml
+++ b/compose.override.yml
@@ -5,3 +5,7 @@ services:
     environment:
       FASTAPI_ROOT: "/api/des"
     ports: !reset
+  frontend:
+    environment:
+      DASH_BASE_PATHNAME: "/frontend/"
+    # ports: !reset

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,7 @@
 include:
   - dighosp-docs/compose.yml
   - dighosp-des/compose.yml
+  - dighosp-frontend/compose.yml
   - nginx/compose.yml
 
 services:

--- a/dighosp-des/compose.yml
+++ b/dighosp-des/compose.yml
@@ -14,7 +14,7 @@ services:
     volumes:
       - "./dighosp_des:/app/dighosp_des:rw"
     ports:
-      - 8000:8000
+      - "8000:8000"
     secrets:
       - mongo-root-pw
     stop_grace_period: 3s

--- a/dighosp-des/dighosp_des/api.py
+++ b/dighosp-des/dighosp_des/api.py
@@ -7,6 +7,7 @@ from tempfile import NamedTemporaryFile
 from typing import Annotated, Optional, Sequence
 
 import pydantic as pyd
+import orjson
 from bson import ObjectId
 from fastapi import FastAPI, File, Form, HTTPException, Request, status
 from fastapi.responses import RedirectResponse
@@ -183,7 +184,7 @@ def sim_replication(job_id: ObjectIdStr, idx: int) -> ObjectId:
         model.run()
         output = model.result_dump()
 
-        output_bytes = bytes(json.dumps(output), encoding='utf-8')
+        output_bytes = orjson.dumps(output)
 
         fs = GridFS(client['sim'])
         obj_id = fs.put(output_bytes)
@@ -279,4 +280,4 @@ def get_result(job_id: ObjectIdStr, idx: int) -> dict[str, dict]:
             )
 
         fs = GridFS(client['sim'])
-        return json.load(fs.get(ObjectId(result_id)))
+        return orjson.loads(fs.get(ObjectId(result_id)).read())

--- a/dighosp-des/pyproject.toml
+++ b/dighosp-des/pyproject.toml
@@ -20,6 +20,7 @@ redis = "^5.0.7"
 rq = "^1.16.2"
 python-dotenv = "^1.0.1"
 singleton-decorator = "^1.0.0"
+orjson = "^3.10.6"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/dighosp-docs/source/roadmap.md
+++ b/dighosp-docs/source/roadmap.md
@@ -4,7 +4,7 @@
 
 ### 0.1.0
 
-- [ ] Functioning frontend (based on existing [digital-hosp-frontend](https://github.com/cam-digital-hospitals/digital-hosp-frontend))
+- [x] Functioning frontend (based on existing [digital-hosp-frontend](https://github.com/cam-digital-hospitals/digital-hosp-frontend))
 - [x] Initial version of DES service (no integration with other services)
 
 

--- a/dighosp-frontend/Dockerfile
+++ b/dighosp-frontend/Dockerfile
@@ -1,0 +1,27 @@
+FROM python:3.12-slim as builder
+RUN pip install poetry
+
+ENV POETRY_VIRTUALENVS_IN_PROJECT=1
+ENV POETRY_VIRTUALENVS_CREATE=1
+ENV POETRY_CACHE_DIR=/tmp/poetry_cache
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get -y dist-upgrade && apt-get -y install gcc
+RUN mkdir /app
+COPY pyproject.toml poetry.lock /app/
+
+RUN cd /app && poetry install --no-interaction --no-ansi --without dev
+
+######
+
+FROM python:3.12-slim as runtime
+
+ENV PATH="/app/.venv/bin:$PATH"
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+COPY --from=builder /app/ /app/
+
+EXPOSE 8000
+
+CMD gunicorn dighosp_frontend.app:server -b "0.0.0.0:8000" -t ${TIMEOUT:-120} -w ${NUM_WORKERS:-4}

--- a/dighosp-frontend/compose.yml
+++ b/dighosp-frontend/compose.yml
@@ -1,0 +1,17 @@
+services:
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      TIMEOUT: 120
+      WORKERS: 4
+      ASSETS_DIRNAME: "/app/assets"
+      DES_FASTAPI_URL: "http://webproxy/api/des"
+    volumes:
+      - "./dighosp_frontend:/app/dighosp_frontend:rw"
+      - "./services.toml:/app/services.toml:rw"
+      - "../assets:/app/assets:rw"
+    ports:
+      - "8000:8000"
+    stop_grace_period: 3s

--- a/dighosp-frontend/dighosp_frontend/app.py
+++ b/dighosp-frontend/dighosp_frontend/app.py
@@ -1,7 +1,5 @@
 """Main module for the front-end."""
 
-from pathlib import Path
-
 import dash
 import dash_bootstrap_components as dbc
 from dash import html
@@ -11,7 +9,10 @@ from dighosp_frontend import conf
 
 app = dash.Dash(external_stylesheets=[dbc.themes.FLATLY],
                 use_pages=True, suppress_callback_exceptions=True,
-                assets_folder=conf.ASSETS_DIRNAME)
+                assets_folder=conf.ASSETS_DIRNAME,
+                routes_pathname_prefix=conf.BASE_PATH,
+                requests_pathname_prefix=conf.BASE_PATH)
+server = app.server
 
 
 @composition
@@ -23,13 +24,13 @@ def app_main():
     ) as ret:
         with dbc.NavbarSimple(
             brand='Digital Hospitals Demo',
-            brand_href='/#',
+            brand_href=dash.get_relative_path('/#'),
             color='primary',
             dark=True,
             fluid=True
         ):
             with dbc.NavItem():
-                with dbc.NavLink(href='/#'):
+                with dbc.NavLink(href=dash.get_relative_path('/#')):
                     yield "Home"
         yield dash.page_container
     return ret
@@ -37,5 +38,7 @@ def app_main():
 
 app.layout = app_main()
 
+# Runs in Debug mode if this file is run directly.
+# In production, this is not executed.
 if __name__ == "__main__":
-    app.run_server(debug=True)
+    app.run(debug=True)

--- a/dighosp-frontend/dighosp_frontend/components.py
+++ b/dighosp-frontend/dighosp_frontend/components.py
@@ -3,7 +3,7 @@
 from typing import Sequence
 
 import dash_bootstrap_components as dbc
-from dash import dcc, html
+from dash import dcc, html, get_relative_path
 from dash_compose import composition
 
 
@@ -20,7 +20,7 @@ def simple_link_card(href: str, title: str, text: str, **kwargs):
                 yield text
     if disabled:
         return card
-    return dcc.Link(card, href=href)
+    return dcc.Link(card, href=get_relative_path(href))
 
 
 def breadcrumb(labels: Sequence[str], paths: Sequence[str]):
@@ -41,6 +41,7 @@ def breadcrumb(labels: Sequence[str], paths: Sequence[str]):
 
     def crumbs(labels, paths):
         urls = list('/' + s for s in map('/'.join, list(paths[:n] for n in range(len(paths)+1))))
+        urls = [get_relative_path(s) for s in urls]
         x = [crumb(*args) for args in list(zip(labels, urls))]
         del x[-1]['href']
         x[-1]['active'] = True

--- a/dighosp-frontend/dighosp_frontend/conf.py
+++ b/dighosp-frontend/dighosp_frontend/conf.py
@@ -7,6 +7,8 @@ from dotenv import find_dotenv, load_dotenv
 env_get = os.environ.get
 
 # If not Docker, load environment variables manually
+#
+# ASSETS_DIRNAME is relative to the .env file if non-Docker and absolute if Docker
 if not os.path.isfile('/.dockerenv'):
     env_path = find_dotenv('.env', True)
     load_dotenv(env_path)
@@ -16,6 +18,7 @@ else:
 
 
 DES_FASTAPI_URL = env_get('DES_FASTAPI_URL', 'http://localhost/api/des')
+BASE_PATH = env_get('DASH_BASE_PATHNAME', '/')
 
 if __name__ == "__main__":
     print(ASSETS_DIRNAME)

--- a/dighosp-frontend/pyproject.toml
+++ b/dighosp-frontend/pyproject.toml
@@ -19,6 +19,7 @@ requests = "^2.32.3"
 python-dotenv = "^1.0.1"
 toml = "^0.10.2"
 orjson = "^3.10.6"
+gunicorn = "^22.0.0"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -4,7 +4,14 @@ server {
   server_name localhost;
   client_max_body_size 64M;  # Make this big so we can upload .ifc files to the BIM module
 
-  location / {  # If no longer prefix matches, serve from /etc/nginx/html
+  location = / {  # Redirect the root and only the root
+    return 302 /frontend/;
+  }
+
+  location /frontend/ {
+    proxy_pass http://frontend:8000;  # no trailing / = do not strip prefix
+    proxy_read_timeout 180s;  # support longer Dash callbacks
+    proxy_send_timeout 180s;  # support longer Dash callbacks
   }
 
   location /docs/ {


### PR DESCRIPTION
- Set up nginx proxy; set site root to redirect to frontend
- Mark task in `roadmap.md` as completed
- Use `dash.get_relative_path()` to provide prefixed href's
- orjson seems to be slightly faster than default `json.loads()` and `dumps()`