### PR TITLE
Link navigation

### DIFF
--- a/dighosp-docs/source/index.md
+++ b/dighosp-docs/source/index.md
@@ -35,10 +35,13 @@ This website contains the internal documentation for the [Digital Hospitals proj
 
 ## <project:./changelog.md>
 
+<!-- Use hack to enable external relative link, see
+https://github.com/sphinx-doc/sphinx/issues/701, https://stackoverflow.com/a/31820846 -->
 :::{toctree}
 :hidden:
 
 🏠 Home <self>
+🔗Frontend </#http://>
 :::
 
 :::{toctree}

--- a/dighosp-frontend/dighosp_frontend/pages/home.py
+++ b/dighosp-frontend/dighosp_frontend/pages/home.py
@@ -32,7 +32,9 @@ def layout():
             yield """\
 # Digital Hospitals demo
 
-**Authors: ** Digital Hospitals group, Institute for Manufacturing, University of Cambridge
+**Authors: ** [Digital Hospitals group](https://www.ifm.eng.cam.ac.uk/research/dial/\
+research-projects/current-projects/distributed-information-and-automation-laboratory/),
+Institute for Manufacturing, University of Cambridge
 
 This website provides a demonstrator for the Digital Hospitals platform for Addenbrooke's Hospital,
 Cambridge, using the Histopathology laboratory as an initial case study.

--- a/dighosp-frontend/services.toml
+++ b/dighosp-frontend/services.toml
@@ -3,11 +3,3 @@ href = "/des"
 name = "Simulation"
 description = "Discrete-event simulation of the histopathology lab."
 color = "#99c7ff"
-
-[bim]
-href = "/bim"
-name = "Building information modelling"
-description = """Compute runner times for the \
-                 histopathology processes based on the building layout."""
-color = "light"
-disabled = true


### PR DESCRIPTION
- Add link to project webpage on DIAL website (frontend: home.py)
- Add link to frontend from internal docs
- Remove not-yet-implemented module from frontend home page