### PR TITLE
Add depends_on entries to webproxy Dockerfile

### DIFF
--- a/nginx/compose.yml
+++ b/nginx/compose.yml
@@ -3,5 +3,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    depends_on:
+      - docs
+      - frontend
+      - mongo-express
+      - des-api
     ports:
       - "80:80"


### PR DESCRIPTION
Hopefully, this fixes some occasional 502 errors after rebuilding -- if not, `docker compose down && docker compose up -d --build` again. (Or `docker-down and docker-restart` if aliased.)